### PR TITLE
build(gulp): clean public folder before starting other gulp tasks

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -3,6 +3,7 @@ const srcDir = './src'
 module.exports = {
   'src': srcDir,
   'dest': './static',
+  'public': './public',
   'env': {
     'prod': {
       'baseUrl': 'https://docs.flyntwp.com/'

--- a/gulpfile.js/tasks/clean.js
+++ b/gulpfile.js/tasks/clean.js
@@ -5,7 +5,8 @@ module.exports = function (config) {
   gulp.task('clean', function () {
     return del([
       config.dest + '/**/*',
-      '!' + config.dest + '/.gitkeep'
+      '!' + config.dest + '/.gitkeep',
+      config.public + '/**/*'
     ])
   });
 }


### PR DESCRIPTION
not running before hugo build to save time on watch tasks, some small issues might occur, but are
worth it in this case