### PR TITLE
fix(core/customization): remove rupture dependency

### DIFF
--- a/content/guide/core/customization.md
+++ b/content/guide/core/customization.md
@@ -33,7 +33,6 @@ const gulp = require('gulp')
 const gulpIf = require('gulp-if')
 const handleErrors = require('../utils/handleErrors')
 const path = require('path')
-const rupture = require('rupture')
 const sourcemaps = require('gulp-sourcemaps')
 const sass = require('gulp-sass')
 
@@ -46,7 +45,6 @@ module.exports = function (config) {
     .pipe(sass({
       compress: isProduction,
       use: [
-        rupture(),
         autoprefixer()
       ],
       import: [


### PR DESCRIPTION
Rupture is a Stylus package and should therefore not be in here as stated in the text above the example.